### PR TITLE
Make the mesh hold together under a race

### DIFF
--- a/helix-view/src/p2p/proto.rs
+++ b/helix-view/src/p2p/proto.rs
@@ -15,8 +15,18 @@ const MAX_FRAME_SIZE: usize = 16 * 1024 * 1024;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Message {
-    Hello { addr: EndpointAddr },
-    Welcome { peers: Vec<EndpointAddr> },
+    Hello {
+        addr: EndpointAddr,
+    },
+    Welcome {
+        peers: Vec<EndpointAddr>,
+    },
+    /// Who the sender is connected to. A peer that is missing one of them
+    /// dials it, which is how the mesh closes a hole it was left with.
+    Peers {
+        peers: Vec<EndpointAddr>,
+    },
+    /// The layer above's to interpret.
     Data(Vec<u8>),
 }
 

--- a/helix-view/src/p2p/session.rs
+++ b/helix-view/src/p2p/session.rs
@@ -3,52 +3,149 @@
 //! A session is a full mesh: every peer holds one connection to every other
 //! peer. A peer joins by dialing any member with a ticket, and is answered
 //! with the addresses of the rest of the session.
+//!
+//! The mesh repairs itself. Peers keep telling each other who they are
+//! connected to, and a peer dials whoever it is missing, so a hole left by two
+//! peers joining at the same moment, or by a link that broke, closes on its
+//! own. Every dial is idempotent, which is what lets the same peer be announced
+//! any number of times.
 
 use std::{
     collections::{HashMap, HashSet},
     str::FromStr,
     sync::{Arc, Mutex},
+    time::Duration,
 };
 
-use anyhow::{bail, ensure, Result};
+use anyhow::{anyhow, bail, ensure, Context, Result};
 use iroh::{
-    endpoint::{Connection, RecvStream, SendStream},
+    endpoint::{Connection, ConnectionError, RecvStream, SendStream},
     protocol::{AcceptError, ProtocolHandler},
     Endpoint, EndpointAddr, EndpointId,
 };
 use iroh_tickets::endpoint::EndpointTicket;
-use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+use rand::Rng;
+use tokio::{
+    sync::mpsc::{channel, error::TrySendError, Receiver, Sender, UnboundedSender},
+    time::{sleep, timeout},
+};
 
 use super::{
     proto::{self, Message},
     Event, ALPN,
 };
 
+/// Why a connection was closed. A peer that hears `BYE` is gone and is not
+/// dialed again; one that hears `DUPLICATE` or `OVERRUN` is still there, and it
+/// is the connection that went.
 const BYE: u32 = 0;
+const DUPLICATE: u32 = 1;
+const OVERRUN: u32 = 2;
+
+const DIAL_TIMEOUT: Duration = Duration::from_secs(30);
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// How often a peer tells the session who it is connected to.
+const GOSSIP_INTERVAL: Duration = Duration::from_secs(15);
+
+/// How many messages may be waiting for one peer. The layer above cannot use a
+/// stream that quietly skipped a message, so a peer this far behind loses its
+/// connection instead, and the redial resynchronises it.
+const OUTBOX_CAPACITY: usize = 1024;
+
+const REDIAL_DELAY: Duration = Duration::from_millis(500);
+const REDIAL_DELAY_MAX: Duration = Duration::from_secs(30);
+const REDIAL_JITTER: Duration = Duration::from_millis(250);
+/// How many times in a row a dial may fail before the peer is given up on.
+const REDIAL_ATTEMPTS: u32 = 20;
 
 #[derive(Debug)]
 struct Peer {
     addr: EndpointAddr,
+    /// Names the connection rather than the peer, so that the task serving one
+    /// can tell "the peer left" from "the peer is here, on the connection that
+    /// replaced mine".
+    token: u64,
+    /// Whether this is the connection of the pair that both sides keep.
+    canonical: bool,
     connection: Connection,
-    outbox: UnboundedSender<Message>,
+    outbox: Sender<Message>,
+}
+
+/// Everything one lock covers, because the decisions taken here span all of it:
+/// admitting a connection reads the peer it would replace, the session it
+/// belongs to, and the dial it completes.
+#[derive(Debug, Default)]
+struct State {
+    /// Bumped whenever the user closes the session. Work that was in flight
+    /// carries the generation it started in and is turned away, so a dial that
+    /// lands late cannot reopen a session that was closed.
+    generation: u64,
+    /// Handed out to connections, never reused.
+    tokens: u64,
+    peers: HashMap<EndpointId, Peer>,
+    /// Peers a task is trying to reach.
+    dialing: HashSet<EndpointId>,
 }
 
 #[derive(Debug, Clone)]
 pub struct Session {
     endpoint: Endpoint,
     events: UnboundedSender<Event>,
-    peers: Arc<Mutex<HashMap<EndpointId, Peer>>>,
-    dialing: Arc<Mutex<HashSet<EndpointId>>>,
+    state: Arc<Mutex<State>>,
+}
+
+/// What a connection got out of being admitted.
+struct Admission {
+    token: u64,
+    queue: Receiver<Message>,
+    /// The rest of the session, taken while the peer was let in.
+    peers: Vec<EndpointAddr>,
+    /// False when this connection replaced another one to the same peer, which
+    /// the editor was already told about.
+    fresh: bool,
+}
+
+/// How serving a connection ended, for the task that dialed it.
+enum Outcome {
+    /// Nothing left to do: the peer left, the session closed, or another
+    /// connection to the same peer took over.
+    Done,
+    /// The connection broke while the peer was still wanted.
+    Dropped,
+}
+
+/// Holds a peer's place while a task is reaching it, so that a welcome naming
+/// the same peer twice, gossip repeating what we are already doing, and a
+/// redial waiting out its backoff do not each open a connection.
+struct Dialing {
+    session: Session,
+    id: EndpointId,
+}
+
+impl Drop for Dialing {
+    fn drop(&mut self) {
+        self.session.state.lock().unwrap().dialing.remove(&self.id);
+    }
 }
 
 impl Session {
     pub fn new(endpoint: Endpoint, events: UnboundedSender<Event>) -> Self {
-        Self {
+        let session = Self {
             endpoint,
             events,
-            peers: Arc::default(),
-            dialing: Arc::default(),
-        }
+            state: Arc::default(),
+        };
+
+        let gossiping = session.clone();
+        tokio::spawn(async move {
+            loop {
+                sleep(GOSSIP_INTERVAL).await;
+                gossiping.gossip();
+            }
+        });
+
+        session
     }
 
     fn id(&self) -> EndpointId {
@@ -63,119 +160,308 @@ impl Session {
         self.emit(Event::Error(error));
     }
 
+    /// A ticket is an address: the session it names is whatever the peer at
+    /// that address is part of when it is used.
     pub fn ticket_new(&self) -> String {
         EndpointTicket::new(self.endpoint.addr()).to_string()
     }
 
     pub fn ticket_join(&self, ticket: &str) -> Result<()> {
         let ticket = EndpointTicket::from_str(ticket)?;
-        let addr = ticket.endpoint_addr().clone();
+        self.dial(ticket.endpoint_addr().clone())
+    }
 
-        ensure!(addr.id != self.id(), "cannot join your own session");
-        ensure!(
-            !self.peers.lock().unwrap().contains_key(&addr.id),
-            "already connected to {}",
-            addr.id.fmt_short()
-        );
+    pub fn ticket_peers(&self) -> Vec<EndpointId> {
+        self.state.lock().unwrap().peers.keys().copied().collect()
+    }
 
-        self.start_connect(addr);
+    pub fn ticket_close(&self) -> Result<()> {
+        let peers = {
+            let mut state = self.state.lock().unwrap();
+            state.generation += 1;
+            state.dialing.clear();
+            std::mem::take(&mut state.peers)
+        };
+
+        for (id, peer) in peers {
+            peer.connection.close(BYE.into(), b"bye");
+            self.emit(Event::Disconnected(id));
+        }
 
         Ok(())
     }
 
     pub fn broadcast(&self, data: Vec<u8>) -> Result<()> {
-        let peers = self.peers.lock().unwrap();
-        ensure!(!peers.is_empty(), "not in a session");
+        let state = self.state.lock().unwrap();
+        ensure!(!state.peers.is_empty(), "not in a session");
 
-        for peer in peers.values() {
-            let _ = peer.outbox.send(Message::Data(data.clone()));
+        for (id, peer) in state.peers.iter() {
+            self.post(*id, peer, Message::Data(data.clone()));
         }
+
         Ok(())
     }
 
-    pub fn ticket_peers(&self) -> Vec<EndpointId> {
-        self.peers.lock().unwrap().keys().copied().collect()
-    }
-
-    pub fn ticket_close(&self) -> Result<()> {
-        let peers = std::mem::take(&mut *self.peers.lock().unwrap());
-        for (id, peer) in peers {
-            peer.connection.close(BYE.into(), b"bye");
-            self.emit(Event::Disconnected(id));
-        }
-        Ok(())
-    }
-
-    fn start_connect(&self, addr: EndpointAddr) {
+    /// Reaches a peer, retrying while the connection keeps breaking. Turns away
+    /// a peer that is already connected or already being reached, which is what
+    /// makes it safe to call for every address a welcome or gossip carries.
+    fn dial(&self, addr: EndpointAddr) -> Result<()> {
         let id = addr.id;
-        if id == self.id()
-            || self.peers.lock().unwrap().contains_key(&id)
-            || !self.dialing.lock().unwrap().insert(id)
-        {
-            return;
-        }
+        ensure!(id != self.id(), "cannot join your own session");
+
+        let generation = {
+            let mut state = self.state.lock().unwrap();
+            ensure!(
+                !state.peers.contains_key(&id),
+                "already connected to {}",
+                id.fmt_short()
+            );
+            ensure!(
+                state.dialing.insert(id),
+                "already connecting to {}",
+                id.fmt_short()
+            );
+            state.generation
+        };
+
+        let dialing = Dialing {
+            session: self.clone(),
+            id,
+        };
 
         let session = self.clone();
-        tokio::spawn(async move {
-            let result = session.connect(addr).await;
-            session.dialing.lock().unwrap().remove(&id);
-            if let Err(err) = result {
-                session.report(format!(
-                    "failed to connect to {}: {:#}",
-                    id.fmt_short(),
-                    err
-                ));
-            }
-        });
+        tokio::spawn(async move { session.redial(generation, addr, dialing).await });
+
+        Ok(())
     }
 
-    async fn connect(&self, addr: EndpointAddr) -> Result<()> {
-        let connection = self.endpoint.connect(addr.clone(), ALPN).await?;
-        let (mut send, mut recv) = connection.open_bi().await?;
+    /// Keeps a peer connected. The place in `dialing` is held for as long as
+    /// this runs, waits included, so nothing else dials the peer behind it.
+    async fn redial(&self, generation: u64, addr: EndpointAddr, _dialing: Dialing) {
+        let id = addr.id;
+        let mut delay = REDIAL_DELAY;
+        let mut failures = 0;
 
-        proto::write(
-            &mut send,
-            &Message::Hello {
-                addr: self.endpoint.addr(),
-            },
-        )
-        .await?;
+        loop {
+            match self.connect(generation, addr.clone()).await {
+                Ok(Outcome::Done) => return,
+                Ok(Outcome::Dropped) => {
+                    // The peer was reachable a moment ago, so start over rather
+                    // than carry a backoff from whenever it was last down.
+                    delay = REDIAL_DELAY;
+                    failures = 0;
+                }
+                Err(err) => {
+                    // Only the first failure is worth a message. The ones after
+                    // it are the same failure, once per attempt.
+                    if failures == 0 {
+                        self.report(format!(
+                            "failed to connect to {}: {:#}",
+                            id.fmt_short(),
+                            err
+                        ));
+                    }
 
-        let Some(Message::Welcome { peers }) = proto::read(&mut recv).await? else {
+                    failures += 1;
+                    if failures >= REDIAL_ATTEMPTS {
+                        self.report(format!("gave up reaching {}", id.fmt_short()));
+                        return;
+                    }
+                }
+            }
+
+            // Jittered, so that a session that lost a peer all at once does not
+            // dial it back in lockstep.
+            let jitter = rand::rng().random_range(Duration::ZERO..REDIAL_JITTER);
+            sleep(delay + jitter).await;
+            delay = (delay * 2).min(REDIAL_DELAY_MAX);
+
+            if !self.wanted(generation, id) {
+                return;
+            }
+        }
+    }
+
+    async fn connect(&self, generation: u64, addr: EndpointAddr) -> Result<Outcome> {
+        let connection = timeout(DIAL_TIMEOUT, self.endpoint.connect(addr.clone(), ALPN))
+            .await
+            .context("timed out dialing")??;
+
+        let (mut send, mut recv) = timeout(HANDSHAKE_TIMEOUT, connection.open_bi())
+            .await
+            .context("timed out opening the session stream")??;
+
+        let hello = Message::Hello {
+            addr: self.endpoint.addr(),
+        };
+        timeout(HANDSHAKE_TIMEOUT, proto::write(&mut send, &hello))
+            .await
+            .context("timed out sending the hello")??;
+
+        let welcome = timeout(HANDSHAKE_TIMEOUT, proto::read(&mut recv))
+            .await
+            .context("timed out waiting for the welcome")??;
+        let Some(Message::Welcome { peers }) = welcome else {
             bail!("expected a welcome");
         };
 
-        for peer in peers {
-            self.start_connect(peer);
-        }
+        let Some(admission) = self.enter(generation, addr.clone(), &connection, true) else {
+            return Ok(Outcome::Done);
+        };
 
-        self.serve(addr, connection, send, recv).await;
+        // The welcome names the rest of the session, which is what makes
+        // joining transitive.
+        self.meet(peers);
 
-        Ok(())
+        Ok(self
+            .serve(addr, connection, send, recv, admission, true)
+            .await)
     }
 
-    async fn answer(&self, connection: Connection) -> Result<()> {
-        let (mut send, mut recv) = connection.accept_bi().await?;
+    async fn answer(&self, generation: u64, connection: Connection) -> Result<()> {
+        let (mut send, mut recv) = timeout(HANDSHAKE_TIMEOUT, connection.accept_bi())
+            .await
+            .context("timed out waiting for the session stream")??;
 
-        let Some(Message::Hello { addr }) = proto::read(&mut recv).await? else {
+        let hello = timeout(HANDSHAKE_TIMEOUT, proto::read(&mut recv))
+            .await
+            .context("timed out waiting for the hello")??;
+        let Some(Message::Hello { addr }) = hello else {
             bail!("expected a hello");
         };
+        // The address is peer input, and the rest of the session will dial what
+        // it says, so it has to describe the peer the connection authenticated.
         ensure!(
             addr.id == connection.remote_id(),
             "hello address does not match the connection identity",
         );
 
-        proto::write(
-            &mut send,
-            &Message::Welcome {
-                peers: self.addrs(),
-            },
-        )
-        .await?;
+        let Some(admission) = self.enter(generation, addr.clone(), &connection, false) else {
+            return Ok(());
+        };
 
-        self.serve(addr, connection, send, recv).await;
+        // Written before the writer starts, so that it is the first frame on
+        // the stream, and from a list taken as the newcomer was let in, so that
+        // two peers admitted at the same moment are named to each other.
+        let welcome = Message::Welcome {
+            peers: admission.peers.clone(),
+        };
+        let written = match timeout(HANDSHAKE_TIMEOUT, proto::write(&mut send, &welcome)).await {
+            Ok(result) => result,
+            Err(_) => Err(anyhow!("timed out sending the welcome")),
+        };
+
+        if let Err(err) = written {
+            if self.leave(addr.id, admission.token) {
+                connection.close(BYE.into(), b"bye");
+                if !admission.fresh {
+                    // We took a peer the editor knows about off its old
+                    // connection and then lost this one.
+                    self.emit(Event::Disconnected(addr.id));
+                }
+            }
+            return Err(err);
+        }
+
+        self.serve(addr, connection, send, recv, admission, false)
+            .await;
 
         Ok(())
+    }
+
+    /// Files a connection under its peer, deciding between it and one that is
+    /// already there.
+    ///
+    /// Two peers can dial each other at the same time and end up holding two
+    /// connections. The pair keeps the one dialed by the lower endpoint id:
+    /// both sides reach that from the connection alone, so neither has to ask
+    /// the other which one to drop. A lone connection is kept whichever side
+    /// opened it, since there is no pair to agree on.
+    fn enter(
+        &self,
+        generation: u64,
+        addr: EndpointAddr,
+        connection: &Connection,
+        dialed: bool,
+    ) -> Option<Admission> {
+        let id = addr.id;
+        let canonical = dialed == (self.id() < id);
+
+        let mut state = self.state.lock().unwrap();
+
+        // The session this connection was opened for has been closed since.
+        if state.generation != generation {
+            connection.close(BYE.into(), b"bye");
+            return None;
+        }
+
+        let mut fresh = true;
+        if let Some(peer) = state.peers.get(&id) {
+            // A connection that is already closed is not a tie to break: it is
+            // the one that went, and this is what the peer has left.
+            let dead = peer.connection.close_reason().is_some();
+            let wins = dead || (canonical && !peer.canonical);
+            if !wins {
+                connection.close(DUPLICATE.into(), b"duplicate");
+                return None;
+            }
+
+            peer.connection.close(DUPLICATE.into(), b"duplicate");
+            // The peer never left, so the editor is not told that it did.
+            fresh = false;
+        }
+
+        state.tokens += 1;
+        let token = state.tokens;
+        let (outbox, queue) = channel(OUTBOX_CAPACITY);
+
+        state.peers.insert(
+            id,
+            Peer {
+                addr,
+                token,
+                canonical,
+                connection: connection.clone(),
+                outbox,
+            },
+        );
+
+        let peers = state
+            .peers
+            .values()
+            .filter(|peer| peer.addr.id != id)
+            .map(|peer| peer.addr.clone())
+            .collect();
+
+        Some(Admission {
+            token,
+            queue,
+            peers,
+            fresh,
+        })
+    }
+
+    /// Takes a connection's peer out, unless the entry has since been filed by
+    /// a newer connection to the same peer.
+    fn leave(&self, id: EndpointId, token: u64) -> bool {
+        let mut state = self.state.lock().unwrap();
+
+        let ours = state.peers.get(&id).is_some_and(|peer| peer.token == token);
+        if ours {
+            state.peers.remove(&id);
+        }
+
+        ours
+    }
+
+    fn member(&self, id: EndpointId, token: u64) -> bool {
+        let state = self.state.lock().unwrap();
+        state.peers.get(&id).is_some_and(|peer| peer.token == token)
+    }
+
+    fn wanted(&self, generation: u64, id: EndpointId) -> bool {
+        let state = self.state.lock().unwrap();
+        state.generation == generation && !state.peers.contains_key(&id)
     }
 
     async fn serve(
@@ -184,37 +470,55 @@ impl Session {
         connection: Connection,
         send: SendStream,
         mut recv: RecvStream,
-    ) {
+        admission: Admission,
+        dialed: bool,
+    ) -> Outcome {
         let id = addr.id;
-        let (outbox, queue) = unbounded_channel();
+        let token = admission.token;
 
-        self.peers.lock().unwrap().insert(
-            addr.id,
-            Peer {
-                addr,
-                connection: connection.clone(),
-                outbox,
-            },
-        );
-        self.start_writer(connection.clone(), send, queue);
-        self.emit(Event::Connected(id));
+        self.start_writer(connection.clone(), send, admission.queue);
+        if admission.fresh {
+            self.emit(Event::Connected(id));
+        }
+        // Tell the session about the peer that just arrived, so that a mesh
+        // with a hole in it closes now rather than at the next round of gossip.
+        self.gossip();
 
-        loop {
+        let reconnect = loop {
             match proto::read(&mut recv).await {
-                Ok(Some(message)) => self.handle(id, message),
-                Ok(None) => break,
+                Ok(Some(message)) => self.handle(id, token, message),
+                // A finished stream is how a peer says goodbye.
+                Ok(None) => break false,
                 Err(err) => {
-                    if connection.close_reason().is_none() {
+                    let reason = connection.close_reason();
+                    if reason.is_none() {
                         self.report(format!("failed to read from {}: {:#}", id.fmt_short(), err));
                     }
-                    break;
+                    break reconnectable(reason);
                 }
             }
+        };
+
+        // A connection that was replaced leaves the peer where it is: the
+        // editor is hearing from it over the connection that took over.
+        if !self.leave(id, token) {
+            return Outcome::Done;
         }
 
-        if self.peers.lock().unwrap().remove(&id).is_some() {
-            connection.close(BYE.into(), b"bye");
-            self.emit(Event::Disconnected(id));
+        connection.close(BYE.into(), b"bye");
+        self.emit(Event::Disconnected(id));
+
+        if !reconnect {
+            return Outcome::Done;
+        }
+
+        if dialed {
+            // The task that dialed this connection is the one that retries it.
+            Outcome::Dropped
+        } else {
+            // Nothing is retrying a connection we only answered, so start.
+            let _ = self.dial(addr);
+            Outcome::Done
         }
     }
 
@@ -222,7 +526,7 @@ impl Session {
         &self,
         connection: Connection,
         mut send: SendStream,
-        mut queue: UnboundedReceiver<Message>,
+        mut queue: Receiver<Message>,
     ) {
         let session = self.clone();
         tokio::spawn(async move {
@@ -241,9 +545,31 @@ impl Session {
         });
     }
 
-    fn handle(&self, from: EndpointId, message: Message) {
+    /// Queues a message for a peer. One that cannot keep up loses its
+    /// connection rather than its place in the order the sender wrote in.
+    fn post(&self, id: EndpointId, peer: &Peer, message: Message) {
+        match peer.outbox.try_send(message) {
+            Ok(()) => {}
+            // The writer is gone, which the task serving the peer is already
+            // dealing with.
+            Err(TrySendError::Closed(_)) => {}
+            Err(TrySendError::Full(_)) => {
+                peer.connection.close(OVERRUN.into(), b"too far behind");
+                self.report(format!("{} fell too far behind", id.fmt_short()));
+            }
+        }
+    }
+
+    fn handle(&self, from: EndpointId, token: u64, message: Message) {
         match message {
-            Message::Data(data) => self.emit(Event::Message { from, data }),
+            // A connection that was replaced, or one the user closed, can still
+            // have a frame on the way; the editor has moved on from it.
+            Message::Data(data) => {
+                if self.member(from, token) {
+                    self.emit(Event::Message { from, data })
+                }
+            }
+            Message::Peers { peers } => self.meet(peers),
             Message::Hello { .. } | Message::Welcome { .. } => self.report(format!(
                 "unexpected handshake message from {}",
                 from.fmt_short()
@@ -251,21 +577,56 @@ impl Session {
         }
     }
 
-    fn addrs(&self) -> Vec<EndpointAddr> {
-        self.peers
-            .lock()
-            .unwrap()
-            .values()
-            .map(|peer| peer.addr.clone())
-            .collect()
+    /// Dials the peers we are missing. Ourselves, a peer already connected and
+    /// one already being dialed are all expected here: `dial` turns them away.
+    fn meet(&self, peers: Vec<EndpointAddr>) {
+        for addr in peers {
+            let _ = self.dial(addr);
+        }
+    }
+
+    /// Tells every peer who we are connected to.
+    fn gossip(&self) {
+        let state = self.state.lock().unwrap();
+        // With one peer there is nobody to introduce it to.
+        if state.peers.len() < 2 {
+            return;
+        }
+
+        let addrs: Vec<_> = state.peers.values().map(|peer| peer.addr.clone()).collect();
+
+        for (id, peer) in state.peers.iter() {
+            let peers = addrs
+                .iter()
+                .filter(|addr| addr.id != *id)
+                .cloned()
+                .collect();
+            self.post(*id, peer, Message::Peers { peers });
+        }
+    }
+}
+
+/// Whether a closed connection is one to open again. A peer that said goodbye,
+/// and a connection dropped in favour of another one to the same peer, are not.
+fn reconnectable(reason: Option<ConnectionError>) -> bool {
+    match reason {
+        // The stream failed under a connection that is still up, which leaves
+        // the session with no way to talk over it.
+        None => true,
+        Some(ConnectionError::TimedOut | ConnectionError::Reset) => true,
+        Some(ConnectionError::ApplicationClosed(close)) => {
+            u64::from(close.error_code) == u64::from(OVERRUN)
+        }
+        Some(_) => false,
     }
 }
 
 impl ProtocolHandler for Session {
     async fn accept(&self, connection: Connection) -> Result<(), AcceptError> {
         let remote = connection.remote_id();
+        let generation = self.state.lock().unwrap().generation;
 
-        if let Err(err) = self.answer(connection).await {
+        if let Err(err) = self.answer(generation, connection).await {
             self.report(format!(
                 "failed to accept connection from {}: {:#}",
                 remote.fmt_short(),


### PR DESCRIPTION
Since #27 the session is a mesh, and a mesh has moments where two connections
to the same peer exist at once. The peer map was not written for those moments,
so a reconnect, a pair of simultaneous joins, or a close landing on an in flight
dial could leave it describing a session that is not the one we have.

This fixes the nine races below and gives the mesh a way to repair itself.

## What was wrong

`Session` kept two mutexes, `peers` and `dialing`, and treated a peer's entry in
the map as *the peer* rather than as *one connection to it*. `serve` inserted on
the way in and removed on the way out, both without looking at what was already
there:

```rust
self.peers.lock().unwrap().insert(addr.id, Peer { .. });   // overwrites
...
if self.peers.lock().unwrap().remove(&id).is_some() { .. } // whose entry?
```

Everything below follows from those two lines and from the checks around them
being taken under a different lock than the one that acts on them.

### 1. A dying connection evicts the one that replaced it

The link between A and B stalls. A's read loop is parked on a read that will not
fail until the idle timeout, while B gives up sooner and dials again:

```
B         reconnects, dials A
A.answer  inserts B, overwriting the stalled entry
A.serve   (new) runs, everything works
A.serve   (old) finally errors out
A.serve   (old) removes B from `peers`      <- removes the NEW entry
A         emits Disconnected(B)
```

A is now connected to B and still raising `Event::Message` from it, but B is in
neither `ticket_peers` nor `broadcast`, and the editor was told B left. The peer
is invisible and unreachable until one side restarts.

**Fixed** by giving every connection a token and filing it on the peer:

```rust
struct Peer {
    /// Names the connection rather than the peer, so that the task serving one
    /// can tell "the peer left" from "the peer is here, on the connection that
    /// replaced mine".
    token: u64,
    ..
}
```

`leave` removes an entry only while it still holds its own token, so the loop
above finds a token that is not its own, removes nothing, and returns without
reporting anything.

### 2. The tie break in #27's description was not in #27

> Two peers may invite each other at the same time and end up with two
> connections. Both keep the one dialed by the lower endpoint id

That was true when it was written and stopped being true two commits later, in
*Let the newcomer open every connection*, which removed the tie break on the
grounds that nobody dials a newcomer back. Nobody does, but two users who swap
tickets and both run `:ticket-join` still dial each other, and then race 1
follows immediately on both sides.

**Fixed** by putting the tie break back, derived from the connection alone:

```rust
let canonical = dialed == (self.id() < id);
```

Worked through, with `A < B`:

```
A dials B -> connection P          B dials A -> connection Q

on A:  P is ours, and A < B  -> canonical      Q -> not canonical
on B:  P is theirs, and A < B -> canonical     Q -> not canonical
```

Both sides keep P and close Q with `DUPLICATE`, without exchanging a message
about it. A connection with nothing to be tied against is kept whichever side
opened it, and an entry whose connection is already closed is replaced outright
rather than tie broken, so this never drops the only link to a peer.

### 3. Two peers joining at once are never introduced

`answer` built the welcome before `serve` registered the newcomer, so two
newcomers admitted by the same host in the same instant were each absent from
the other's welcome:

```
A is in a session with B. C and D join A at the same time.

A.answer(C)   addrs() -> [B]     writes Welcome { peers: [B] }
A.answer(D)   addrs() -> [B]     writes Welcome { peers: [B] }
A.serve(C)    inserts C
A.serve(D)    inserts D

C dials B, D dials B, and nobody dials a newcomer back.
C and D never connect.
```

The mesh is missing an edge and nothing ever notices. This is the case #27 left
for later.

**Fixed** by taking the welcome in the same lock that admits the peer. `enter`
inserts the newcomer and then reads the map for the welcome, so whichever of C
and D is admitted second is told about the first and dials it.

### 4. `ticket_close` did not cancel what was in flight

It emptied `peers` and left `dialing` alone, and there was no closed state for a
dial to notice:

```
user      :ticket-join <ticket>
session   marks `dialing`, spawns the dial
user      :ticket-close          -> `peers` emptied
dial      lands, `serve` inserts the peer, emits Connected
```

The user is back in a session they closed. A `Data` frame already on the wire
reached the editor the same way.

**Fixed** with a generation on the state, bumped by `ticket_close`. Every task
carries the generation it started in; `enter` turns away a connection whose
generation has moved on and closes it, and `handle` drops a frame from a
connection that is no longer a member.

### 5. `dialing` meant two things and leaked

`start_connect` removed the mark only after `connect` returned, and `connect`
contained the whole read loop, so a peer was marked as being dialed for as long
as it was connected. A panic anywhere in the task left the mark set, and the
peer could never be dialed again.

**Fixed** by making the mark a guard that a task owns for exactly as long as it
is trying to reach the peer, including its backoff waits:

```rust
struct Dialing { session: Session, id: EndpointId }

impl Drop for Dialing {
    fn drop(&mut self) {
        self.session.state.lock().unwrap().dialing.remove(&self.id);
    }
}
```

### 6. `ticket_join` checked one thing and did another

`ticket_join` refused a peer already in `peers`, then called `start_connect`,
which checked `peers` and `dialing` again under different locks and returned
nothing when it declined. A second `:ticket-join` while the first dial was still
in flight passed the check, was dropped by `start_connect`, and reported success.

**Fixed** by folding the checks into `dial`, which takes the lock once, decides,
and returns the reason it declined:

```rust
ensure!(!state.peers.contains_key(&id), "already connected to {}", id.fmt_short());
ensure!(state.dialing.insert(id), "already connecting to {}", id.fmt_short());
```

### 7. The editor's events did not describe peers

`Connected` and `Disconnected` were emitted once per *connection*. A duplicate
connection raised a second `Connected` for a peer already connected, and races 1
and 4 raised `Disconnected` for peers that had not gone anywhere. The CRDT layer
of #16 will key document state off these, and it cannot key it off a stream that
says a peer arrived twice.

**Fixed**: `Connected` is raised only when the connection did not replace one to
the same peer, and `Disconnected` only when `leave` actually took the peer out.
A peer whose connection is swapped underneath it produces no event at all, which
is right: it never left.

### 8. An outbox could grow without limit

`unbounded_channel` per peer, fed by `broadcast`. A peer that stops reading
takes the session's memory with it.

**Fixed**: the outbox is bounded at 1024 messages. A peer that falls that far
behind loses its connection and is resynchronised by the redial, rather than the
session growing without limit or quietly skipping a message. Skipping is not an
option the layer above has: the messages arrive in the order the sender wrote
them, and a document rebuilt from a stream with a hole in it is wrong.

### 9. Nothing timed out and nothing was retried

`answer` awaited `accept_bi` and the hello forever, so a peer that connected and
said nothing held a task for good. And any failure at all, a laptop lid, a
change of network, removed a peer from the mesh permanently.

**Fixed**: the dial has a 30s timeout and each handshake step a 10s one. A
connection that breaks is dialed again with a jittered backoff from 500ms to
30s, giving up after twenty consecutive failures. A peer that said goodbye, and
a connection dropped for a duplicate, are not dialed again.

## Repairing the mesh

The fix in race 3 closes the hole a join can leave, but it is not the only way
to get one: a welcome can race a departure, a peer can be unreachable at the
moment it is named, a link can break on one edge of an otherwise healthy mesh.

So peers now tell each other who they are connected to, on arrival and every
fifteen seconds after, and dial whoever they are missing:

```rust
Message::Peers { peers: Vec<EndpointAddr> }
```

Dialing is idempotent, which is what makes this safe to run on a timer: being
told about a peer we already have, are already dialing, or are ourselves, costs
one refused call.

Any hole closes within a round:

```
A - B, A - C, B and C not connected.

A gossips [C] to B and [B] to C.
Whichever gets there first dials, the other's dial is refused as a duplicate.
```

## Also

`peers` and `dialing` are now one `State` behind one lock, because every
decision here spans both: admitting a connection reads the peer it would
replace, the session it belongs to, and the dial it completes.

## Worth a second opinion

Across a link flap the editor now sees `Disconnected` then `Connected` for that
peer, where before it saw the peer vanish. That is deliberate: the layer above
needs to know the link was down so it can resynchronise when it comes back. It
does mean a flap is visible in the status line.

`REDIAL_ATTEMPTS` at twenty, with the backoff capped at 30s, gives up on an
unreachable peer after roughly nine minutes. That is a guess at how long a
session should keep a seat warm for someone who closed their laptop.
