### PR TITLE
Type into the same buffer from two editors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2198,6 +2198,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "quickcheck",
+ "rand 0.9.5",
  "regex",
  "regex-cursor",
  "ropey",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,6 +442,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cola"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "242a0cf7940e81cc943599ce00889a975ca13abacfaff4f11796028193603ece"
+dependencies = [
+ "serde",
+ "sha2 0.10.9",
+ "unsigned-varint",
+ "varint-simd",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,7 +756,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 2.0.101",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -875,7 +887,7 @@ dependencies = [
  "ed25519",
  "rand_core 0.10.0",
  "serde",
- "sha2",
+ "sha2 0.11.0",
  "signature",
  "subtle",
  "zeroize",
@@ -2172,6 +2184,7 @@ dependencies = [
  "arc-swap",
  "bitflags",
  "chrono",
+ "cola",
  "encoding_rs",
  "foldhash 0.2.0",
  "globset",
@@ -2256,7 +2269,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "serde",
- "sha2",
+ "sha2 0.11.0",
  "tempfile",
  "threadpool",
  "toml",
@@ -4771,6 +4784,17 @@ checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
@@ -5678,6 +5702,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unsigned-varint"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5718,6 +5748,15 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "varint-simd"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "655d0cf8bfc2bd1f079e767f7ff613cbfa0ef06ca3ceaf1fd6b6cde08cbd012a"
+dependencies = [
+ "rustc_version",
+]
 
 [[package]]
 name = "version_check"

--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -102,6 +102,6 @@
 | `:workspace-exclude` | Mark the current workspace as never-prompt. Never prompts for trust again. |
 | `:session-new` | Create a ticket for the collaborative session and yank it into system clipboard. |
 | `:session-join` | Join a collaborative session with the given ticket. |
-| `:session-send` | Send a message to every peer of the current collaborative session. |
+| `:session-share` | Share the focused document with every peer of the current collaborative session. |
 | `:session-peers` | List the peers of the current collaborative session. |
 | `:session-close` | Leave the current collaborative session. |

--- a/helix-core/Cargo.toml
+++ b/helix-core/Cargo.toml
@@ -39,6 +39,7 @@ regex = "1"
 bitflags.workspace = true
 foldhash.workspace = true
 cola = { version = "0.5", features = ["serde"] }
+rand = "0.9"
 
 log = "0.4"
 anyhow = "1.0"

--- a/helix-core/Cargo.toml
+++ b/helix-core/Cargo.toml
@@ -38,6 +38,7 @@ arc-swap = "1"
 regex = "1"
 bitflags.workspace = true
 foldhash.workspace = true
+cola = { version = "0.5", features = ["serde"] }
 
 log = "0.4"
 anyhow = "1.0"

--- a/helix-core/src/crdt.rs
+++ b/helix-core/src/crdt.rs
@@ -1,0 +1,103 @@
+//! Bridges Helix's [`ChangeSet`]s to [`cola`], a text CRDT.
+//!
+//! cola counts in whatever unit you decide and never checks. Helix indexes
+//! chars, so every `usize` crossing this boundary is a char index.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::Result;
+use cola::{EncodedReplica, Insertion, Replica, ReplicaId};
+use serde::{Deserialize, Serialize};
+
+use crate::{transaction::Operation, ChangeSet, Rope, Transaction};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Op {
+    Insert { insertion: Insertion, text: String },
+    // `cola::` qualified: `helix_core` has its own `Deletion`.
+    Delete(cola::Deletion),
+}
+
+/// TODO: derive this from the peer's `EndpointId` so it survives a reconnect.
+pub fn replica_id() -> ReplicaId {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_nanos() as ReplicaId)
+        .unwrap_or_default();
+
+    // cola panics on a zero id.
+    nanos.max(1)
+}
+
+pub struct DocReplica {
+    replica: Replica,
+}
+
+impl DocReplica {
+    pub fn new(id: ReplicaId, text: &Rope) -> Self {
+        Self {
+            replica: Replica::new(id, text.len_chars()),
+        }
+    }
+
+    /// Forks, so `id` must differ from every other replica in the session:
+    /// cola breaks ties between concurrent insertions by comparing ids, and
+    /// two replicas sharing one silently diverge.
+    pub fn decode(id: ReplicaId, encoded: &[u8]) -> Result<Self> {
+        let encoded = EncodedReplica::from_bytes(encoded);
+        Ok(Self {
+            replica: Replica::decode(id, &encoded)?,
+        })
+    }
+
+    pub fn encode(&self) -> Vec<u8> {
+        self.replica.encode().as_bytes().to_vec()
+    }
+
+    pub fn from_local(&mut self, changes: &ChangeSet) -> Vec<Op> {
+        let mut ops = Vec::new();
+        let mut pos = 0;
+
+        for op in changes.changes() {
+            match op {
+                Operation::Retain(n) => pos += n,
+                Operation::Insert(text) => {
+                    let len = text.chars().count();
+                    ops.push(Op::Insert {
+                        insertion: self.replica.inserted(pos, len),
+                        text: text.to_string(),
+                    });
+                    pos += len;
+                }
+                Operation::Delete(n) => {
+                    ops.push(Op::Delete(self.replica.deleted(pos..pos + n)));
+                }
+            }
+        }
+
+        ops
+    }
+
+    /// `None` means cola backlogged the op, not that it failed.
+    pub fn from_remote(&mut self, text: &Rope, op: &Op) -> Option<Transaction> {
+        match op {
+            Op::Insert { insertion, text: s } => {
+                let at = self.replica.integrate_insertion(insertion)?;
+                Some(Transaction::change(
+                    text,
+                    [(at, at, Some(s.as_str().into()))].into_iter(),
+                ))
+            }
+            Op::Delete(deletion) => {
+                let ranges = self.replica.integrate_deletion(deletion);
+                if ranges.is_empty() {
+                    return None;
+                }
+                Some(Transaction::delete(
+                    text,
+                    ranges.into_iter().map(|range| (range.start, range.end)),
+                ))
+            }
+        }
+    }
+}

--- a/helix-core/src/crdt.rs
+++ b/helix-core/src/crdt.rs
@@ -12,7 +12,6 @@ use crate::{transaction::Operation, ChangeSet, Rope, Transaction};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum RemoteOperation {
     Insert { insertion: Insertion, text: String },
-    // `cola::` qualified: `helix_core` has its own `Deletion`.
     Delete(cola::Deletion),
 }
 

--- a/helix-core/src/crdt.rs
+++ b/helix-core/src/crdt.rs
@@ -3,8 +3,6 @@
 //! cola counts in whatever unit you decide and never checks. Helix indexes
 //! chars, so every `usize` crossing this boundary is a char index.
 
-use std::time::{SystemTime, UNIX_EPOCH};
-
 use anyhow::Result;
 use cola::{EncodedReplica, Insertion, ReplicaId};
 use serde::{Deserialize, Serialize};
@@ -20,13 +18,8 @@ pub enum RemoteOperation {
 
 /// TODO: derive this from the peer's `EndpointId` so it survives a reconnect.
 pub fn replica_id() -> ReplicaId {
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|elapsed| elapsed.as_nanos() as ReplicaId)
-        .unwrap_or_default();
-
     // cola panics on a zero id.
-    nanos.max(1)
+    rand::random_range(1..=ReplicaId::MAX)
 }
 
 pub struct Replica {

--- a/helix-core/src/crdt.rs
+++ b/helix-core/src/crdt.rs
@@ -6,13 +6,13 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::Result;
-use cola::{EncodedReplica, Insertion, Replica, ReplicaId};
+use cola::{EncodedReplica, Insertion, ReplicaId};
 use serde::{Deserialize, Serialize};
 
 use crate::{transaction::Operation, ChangeSet, Rope, Transaction};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum Op {
+pub enum RemoteOperation {
     Insert { insertion: Insertion, text: String },
     // `cola::` qualified: `helix_core` has its own `Deletion`.
     Delete(cola::Deletion),
@@ -29,14 +29,14 @@ pub fn replica_id() -> ReplicaId {
     nanos.max(1)
 }
 
-pub struct DocReplica {
-    replica: Replica,
+pub struct Replica {
+    replica: cola::Replica,
 }
 
-impl DocReplica {
+impl Replica {
     pub fn new(id: ReplicaId, text: &Rope) -> Self {
         Self {
-            replica: Replica::new(id, text.len_chars()),
+            replica: cola::Replica::new(id, text.len_chars()),
         }
     }
 
@@ -46,7 +46,7 @@ impl DocReplica {
     pub fn decode(id: ReplicaId, encoded: &[u8]) -> Result<Self> {
         let encoded = EncodedReplica::from_bytes(encoded);
         Ok(Self {
-            replica: Replica::decode(id, &encoded)?,
+            replica: cola::Replica::decode(id, &encoded)?,
         })
     }
 
@@ -54,7 +54,7 @@ impl DocReplica {
         self.replica.encode().as_bytes().to_vec()
     }
 
-    pub fn from_local(&mut self, changes: &ChangeSet) -> Vec<Op> {
+    pub fn from_local(&mut self, changes: &ChangeSet) -> Vec<RemoteOperation> {
         let mut ops = Vec::new();
         let mut pos = 0;
 
@@ -63,14 +63,14 @@ impl DocReplica {
                 Operation::Retain(n) => pos += n,
                 Operation::Insert(text) => {
                     let len = text.chars().count();
-                    ops.push(Op::Insert {
+                    ops.push(RemoteOperation::Insert {
                         insertion: self.replica.inserted(pos, len),
                         text: text.to_string(),
                     });
                     pos += len;
                 }
                 Operation::Delete(n) => {
-                    ops.push(Op::Delete(self.replica.deleted(pos..pos + n)));
+                    ops.push(RemoteOperation::Delete(self.replica.deleted(pos..pos + n)));
                 }
             }
         }
@@ -79,16 +79,16 @@ impl DocReplica {
     }
 
     /// `None` means cola backlogged the op, not that it failed.
-    pub fn from_remote(&mut self, text: &Rope, op: &Op) -> Option<Transaction> {
+    pub fn from_remote(&mut self, text: &Rope, op: &RemoteOperation) -> Option<Transaction> {
         match op {
-            Op::Insert { insertion, text: s } => {
+            RemoteOperation::Insert { insertion, text: s } => {
                 let at = self.replica.integrate_insertion(insertion)?;
                 Some(Transaction::change(
                     text,
                     [(at, at, Some(s.as_str().into()))].into_iter(),
                 ))
             }
-            Op::Delete(deletion) => {
+            RemoteOperation::Delete(deletion) => {
                 let ranges = self.replica.integrate_deletion(deletion);
                 if ranges.is_empty() {
                     return None;

--- a/helix-core/src/crdt.rs
+++ b/helix-core/src/crdt.rs
@@ -31,9 +31,7 @@ impl Replica {
         }
     }
 
-    /// Forks, so `id` must differ from every other replica in the session:
-    /// Cola breaks ties between concurrent insertions by comparing ids, and
-    /// two replicas sharing one silently diverge.
+    /// Forks, so the id must differ from every other replica in the session.
     pub fn decode(id: ReplicaId, encoded: &[u8]) -> Result<Self> {
         let encoded = EncodedReplica::from_bytes(encoded);
         Ok(Self {
@@ -45,6 +43,7 @@ impl Replica {
         self.replica.encode().as_bytes().to_vec()
     }
 
+    /// Translate local transactions to CRDT operations.
     pub fn from_local(&mut self, changes: &ChangeSet) -> Vec<RemoteOperation> {
         let mut ops = Vec::new();
         let mut pos = 0;
@@ -69,26 +68,26 @@ impl Replica {
         ops
     }
 
+    /// Translate CRDT operations to local transactions.
+    ///
     /// `None` means Cola backlogged the op, not that it failed.
     pub fn from_remote(&mut self, text: &Rope, op: &RemoteOperation) -> Option<Transaction> {
-        match op {
+        let transaction = match op {
             RemoteOperation::Insert { insertion, text: s } => {
                 let at = self.replica.integrate_insertion(insertion)?;
-                Some(Transaction::change(
-                    text,
-                    [(at, at, Some(s.as_str().into()))].into_iter(),
-                ))
+                Transaction::change(text, [(at, at, Some(s.as_str().into()))].into_iter())
             }
             RemoteOperation::Delete(deletion) => {
                 let ranges = self.replica.integrate_deletion(deletion);
                 if ranges.is_empty() {
                     return None;
                 }
-                Some(Transaction::delete(
+                Transaction::delete(
                     text,
                     ranges.into_iter().map(|range| (range.start, range.end)),
-                ))
+                )
             }
-        }
+        };
+        Some(transaction.as_remote())
     }
 }

--- a/helix-core/src/crdt.rs
+++ b/helix-core/src/crdt.rs
@@ -1,6 +1,6 @@
 //! Bridges Helix's [`ChangeSet`]s to [`cola`], a text CRDT.
 //!
-//! cola counts in whatever unit you decide and never checks. Helix indexes
+//! Cola counts in whatever unit you decide and never checks. Helix indexes
 //! chars, so every `usize` crossing this boundary is a char index.
 
 use anyhow::Result;
@@ -15,9 +15,8 @@ pub enum RemoteOperation {
     Delete(cola::Deletion),
 }
 
-/// TODO: derive this from the peer's `EndpointId` so it survives a reconnect.
 pub fn replica_id() -> ReplicaId {
-    // cola panics on a zero id.
+    // Cola panics on a zero id.
     rand::random_range(1..=ReplicaId::MAX)
 }
 
@@ -33,7 +32,7 @@ impl Replica {
     }
 
     /// Forks, so `id` must differ from every other replica in the session:
-    /// cola breaks ties between concurrent insertions by comparing ids, and
+    /// Cola breaks ties between concurrent insertions by comparing ids, and
     /// two replicas sharing one silently diverge.
     pub fn decode(id: ReplicaId, encoded: &[u8]) -> Result<Self> {
         let encoded = EncodedReplica::from_bytes(encoded);
@@ -70,7 +69,7 @@ impl Replica {
         ops
     }
 
-    /// `None` means cola backlogged the op, not that it failed.
+    /// `None` means Cola backlogged the op, not that it failed.
     pub fn from_remote(&mut self, text: &Rope, op: &RemoteOperation) -> Option<Transaction> {
         match op {
             RemoteOperation::Insert { insertion, text: s } => {

--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod command_line;
 pub mod comment;
 pub mod completion;
 pub mod config;
+pub mod crdt;
 pub mod diagnostic;
 pub mod diff;
 pub mod doc_formatter;

--- a/helix-core/src/transaction.rs
+++ b/helix-core/src/transaction.rs
@@ -574,9 +574,8 @@ impl ChangeSet {
 pub struct Transaction {
     changes: ChangeSet,
     selection: Option<Selection>,
-    /// Set when this transaction carries changes received from a remote peer.
-    /// The collaboration hook checks it to avoid feeding those changes back
-    /// into the CRDT (and echoing them to the sender).
+    /// Whether transaction carries changes from a remote peer.
+    /// To avoid propagating changes back.
     remote_transaction: bool,
 }
 
@@ -600,13 +599,10 @@ impl Transaction {
         self.selection.as_ref()
     }
 
-    /// Whether this transaction carries changes received from a remote peer.
     pub fn is_remote(&self) -> bool {
         self.remote_transaction
     }
 
-    /// Mark this transaction as carrying changes received from a remote peer,
-    /// so it is not propagated back to the CRDT.
     pub fn as_remote(mut self) -> Self {
         self.remote_transaction = true;
         self

--- a/helix-core/src/transaction.rs
+++ b/helix-core/src/transaction.rs
@@ -574,6 +574,10 @@ impl ChangeSet {
 pub struct Transaction {
     changes: ChangeSet,
     selection: Option<Selection>,
+    /// Set when this transaction carries changes received from a remote peer.
+    /// The collaboration hook checks it to avoid feeding those changes back
+    /// into the CRDT (and echoing them to the sender).
+    remote_transaction: bool,
 }
 
 impl Transaction {
@@ -582,6 +586,7 @@ impl Transaction {
         Self {
             changes: ChangeSet::new(doc.slice(..)),
             selection: None,
+            remote_transaction: false,
         }
     }
 
@@ -593,6 +598,18 @@ impl Transaction {
     /// When set, explicitly updates the selection.
     pub fn selection(&self) -> Option<&Selection> {
         self.selection.as_ref()
+    }
+
+    /// Whether this transaction carries changes received from a remote peer.
+    pub fn is_remote(&self) -> bool {
+        self.remote_transaction
+    }
+
+    /// Mark this transaction as carrying changes received from a remote peer,
+    /// so it is not propagated back to the CRDT.
+    pub fn as_remote(mut self) -> Self {
+        self.remote_transaction = true;
+        self
     }
 
     /// Returns true if applied successfully.
@@ -612,6 +629,7 @@ impl Transaction {
         Self {
             changes,
             selection: None,
+            remote_transaction: false,
         }
     }
 
@@ -879,6 +897,7 @@ impl From<ChangeSet> for Transaction {
         Self {
             changes,
             selection: None,
+            remote_transaction: false,
         }
     }
 }

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -1,6 +1,10 @@
 use arc_swap::{access::Map, ArcSwap};
 use futures_util::Stream;
-use helix_core::{diagnostic::Severity, pos_at_coords, syntax, Range, Selection};
+use helix_core::{
+    crdt::{replica_id, DocReplica},
+    diagnostic::Severity,
+    pos_at_coords, syntax, Range, Selection, Transaction,
+};
 use helix_lsp::{
     lsp::{self, notification::Notification},
     util::lsp_range_to_range,
@@ -12,7 +16,8 @@ use helix_view::{
     document::{DocumentOpenError, DocumentSavedEventResult},
     editor::{ConfigEvent, EditorEvent},
     graphics::Rect,
-    p2p, theme,
+    p2p::{self, proto::Message},
+    theme,
     tree::Layout,
     Align, Editor,
 };
@@ -131,6 +136,7 @@ impl Application {
             handlers,
             workspace_trust,
         );
+        handlers::collab::register_hooks(editor.p2p_service.requests.clone());
         Self::load_configured_theme(&mut editor, &config.load(), &mut terminal, theme_mode);
 
         let keys = Box::new(Map::new(Arc::clone(&config), |config: &Config| {
@@ -1212,12 +1218,40 @@ impl Application {
                 self.editor
                     .set_status(format!("disconnected with {}", peer.fmt_short()));
             }
-            p2p::Event::Message { from, data } => {
-                self.editor.set_status(format!(
-                    "message from {}: {}",
-                    from.fmt_short(),
-                    String::from_utf8_lossy(&data)
-                ));
+            p2p::Event::Message { message, .. } => {
+                let view_id = self.editor.tree.focus;
+                let doc = doc_mut!(self.editor);
+
+                match message {
+                    Message::Share { text, replica } => {
+                        // Attach the replica *after* the swap, or the hook
+                        // broadcasts it straight back to the sharer.
+                        let transaction = Transaction::change(
+                            doc.text(),
+                            [(0, doc.text().len_chars(), Some(text.as_str().into()))].into_iter(),
+                        );
+                        doc.apply(&transaction, view_id);
+
+                        match DocReplica::decode(replica_id(), &replica) {
+                            Ok(crdt) => doc.crdt = Some(crdt),
+                            Err(err) => {
+                                self.editor.set_error(format!(
+                                    "failed to join the shared document: {err:#}"
+                                ));
+                            }
+                        }
+                    }
+
+                    Message::Edit(op) => {
+                        doc.with_crdt_detached(|doc, crdt| {
+                            if let Some(transaction) = crdt.from_remote(doc.text(), &op) {
+                                doc.apply(&transaction, view_id);
+                            }
+                        });
+                    }
+
+                    Message::Hello { .. } | Message::Welcome { .. } => {}
+                }
             }
             p2p::Event::Error(err) => {
                 self.editor.set_error(err);

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -1,7 +1,7 @@
 use arc_swap::{access::Map, ArcSwap};
 use futures_util::Stream;
 use helix_core::{
-    crdt::{replica_id, DocReplica},
+    crdt::{replica_id, Replica},
     diagnostic::Severity,
     pos_at_coords, syntax, Range, Selection, Transaction,
 };
@@ -1232,7 +1232,7 @@ impl Application {
                         );
                         doc.apply(&transaction, view_id);
 
-                        match DocReplica::decode(replica_id(), &replica) {
+                        match Replica::decode(replica_id(), &replica) {
                             Ok(crdt) => doc.crdt = Some(crdt),
                             Err(err) => {
                                 self.editor.set_error(format!(

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -1243,11 +1243,15 @@ impl Application {
                     }
 
                     Message::Edit(op) => {
-                        doc.with_crdt_detached(|doc, crdt| {
-                            if let Some(transaction) = crdt.from_remote(doc.text(), &op) {
-                                doc.apply(&transaction, view_id);
-                            }
-                        });
+                        // Out of the document for the apply, so the change
+                        // hook skips it instead of echoing it back.
+                        let Some(mut crdt) = doc.crdt.take() else {
+                            return;
+                        };
+                        if let Some(transaction) = crdt.from_remote(doc.text(), &op) {
+                            doc.apply(&transaction, view_id);
+                        }
+                        doc.crdt = Some(crdt);
                     }
 
                     Message::Hello { .. } | Message::Welcome { .. } => {}

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -1224,22 +1224,27 @@ impl Application {
 
                 match message {
                     Message::Share { text, replica } => {
-                        // Attach the replica *after* the swap, or the hook
-                        // broadcasts it straight back to the sharer.
-                        let transaction = Transaction::change(
-                            doc.text(),
-                            [(0, doc.text().len_chars(), Some(text.as_str().into()))].into_iter(),
-                        );
-                        doc.apply(&transaction, view_id);
-
-                        match Replica::decode(replica_id(), &replica) {
-                            Ok(crdt) => doc.crdt = Some(crdt),
+                        let crdt = match Replica::decode(replica_id(), &replica) {
+                            Ok(crdt) => crdt,
                             Err(err) => {
                                 self.editor.set_error(format!(
                                     "failed to join the shared document: {err:#}"
                                 ));
+                                return;
                             }
-                        }
+                        };
+
+                        // Applied as a remote transaction so the hook does not
+                        // feed the snapshot back into the CRDT and echo it to
+                        // the sharer.
+                        let transaction = Transaction::change(
+                            doc.text(),
+                            [(0, doc.text().len_chars(), Some(text.as_str().into()))].into_iter(),
+                        )
+                        .as_remote();
+                        doc.apply(&transaction, view_id);
+
+                        doc.crdt = Some(crdt);
                     }
 
                     Message::Edit(op) => {

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -1227,36 +1227,29 @@ impl Application {
                         let crdt = match Replica::decode(replica_id(), &replica) {
                             Ok(crdt) => crdt,
                             Err(err) => {
-                                self.editor.set_error(format!(
-                                    "failed to join the shared document: {err:#}"
-                                ));
+                                self.editor
+                                    .set_error(format!("failed to join shared session: {err:#}"));
                                 return;
                             }
                         };
+                        doc.crdt = Some(crdt);
 
-                        // Applied as a remote transaction so the hook does not
-                        // feed the snapshot back into the CRDT and echo it to
-                        // the sharer.
                         let transaction = Transaction::change(
                             doc.text(),
                             [(0, doc.text().len_chars(), Some(text.as_str().into()))].into_iter(),
                         )
                         .as_remote();
                         doc.apply(&transaction, view_id);
-
-                        doc.crdt = Some(crdt);
                     }
 
                     Message::Edit(op) => {
-                        // Out of the document for the apply, so the change
-                        // hook skips it instead of echoing it back.
                         let Some(mut crdt) = doc.crdt.take() else {
                             return;
                         };
                         if let Some(transaction) = crdt.from_remote(doc.text(), &op) {
                             doc.apply(&transaction, view_id);
                         }
-                        doc.crdt = Some(crdt);
+                        doc.crdt = Some(crdt)
                     }
 
                     Message::Hello { .. } | Message::Welcome { .. } => {}

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -7,12 +7,14 @@ use crate::job::Job;
 use super::*;
 
 use helix_core::command_line::{Args, Flag, Signature, Token, TokenKind};
+use helix_core::crdt::{replica_id, DocReplica};
 use helix_core::fuzzy::fuzzy_match;
 use helix_core::indent::MAX_INDENT;
 use helix_core::line_ending;
 use helix_stdx::path::home_dir;
 use helix_view::document::{read_to_string, DEFAULT_LANGUAGE_NAME};
 use helix_view::editor::{CloseError, ConfigEvent};
+use helix_view::p2p::proto::Message;
 use helix_view::{expansion, p2p};
 use serde_json::Value;
 use tokio::sync::mpsc::channel;
@@ -3015,20 +3017,23 @@ fn session_join(
     Ok(())
 }
 
-fn session_send(
+fn session_share(
     cx: &mut compositor::Context,
-    args: Args,
+    _args: Args,
     event: PromptEvent,
 ) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
     }
 
-    let message = args
-        .first()
-        .expect("command should have argument")
-        .as_bytes()
-        .to_vec();
+    let doc = doc_mut!(cx.editor);
+    let crdt = DocReplica::new(replica_id(), doc.text());
+    let message = Message::Share {
+        text: doc.text().to_string(),
+        replica: crdt.encode(),
+    };
+    doc.crdt = Some(crdt);
+
     cx.editor
         .p2p_service
         .requests
@@ -4262,14 +4267,13 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         },
     },
     TypableCommand {
-        name: "session-send",
+        name: "session-share",
         aliases: &[],
-        doc: "Send a message to every peer of the current collaborative session.",
-        fun: session_send,
+        doc: "Share the focused document with every peer of the current collaborative session.",
+        fun: session_share,
         completer: CommandCompleter::none(),
         signature: Signature {
-            positionals: (1, Some(1)),
-            raw_after: Some(0),
+            positionals: (0, Some(0)),
             ..Signature::DEFAULT
         },
     },

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -7,7 +7,7 @@ use crate::job::Job;
 use super::*;
 
 use helix_core::command_line::{Args, Flag, Signature, Token, TokenKind};
-use helix_core::crdt::{replica_id, DocReplica};
+use helix_core::crdt::{replica_id, Replica};
 use helix_core::fuzzy::fuzzy_match;
 use helix_core::indent::MAX_INDENT;
 use helix_core::line_ending;
@@ -3027,7 +3027,7 @@ fn session_share(
     }
 
     let doc = doc_mut!(cx.editor);
-    let crdt = DocReplica::new(replica_id(), doc.text());
+    let crdt = Replica::new(replica_id(), doc.text());
     let message = Message::Share {
         text: doc.text().to_string(),
         replica: crdt.encode(),

--- a/helix-term/src/handlers.rs
+++ b/helix-term/src/handlers.rs
@@ -17,6 +17,7 @@ use self::document_links::DocumentLinksHandler;
 
 mod auto_save;
 mod code_action_hint;
+pub mod collab;
 pub mod completion;
 pub mod diagnostics;
 mod document_colors;

--- a/helix-term/src/handlers/collab.rs
+++ b/helix-term/src/handlers/collab.rs
@@ -1,0 +1,23 @@
+use helix_event::register_hook;
+use helix_view::{
+    events::DocumentDidChange,
+    p2p::{self, proto::Message},
+};
+use tokio::sync::mpsc::UnboundedSender;
+
+pub fn register_hooks(requests: UnboundedSender<p2p::Request>) {
+    register_hook!(move |event: &mut DocumentDidChange<'_>| {
+        if event.ghost_transaction {
+            return Ok(());
+        }
+        let Some(crdt) = event.doc.crdt.as_mut() else {
+            return Ok(());
+        };
+
+        for op in crdt.from_local(event.changes) {
+            let _ = requests.send(p2p::Request::Broadcast(Message::Edit(op)));
+        }
+
+        Ok(())
+    });
+}

--- a/helix-term/src/handlers/collab.rs
+++ b/helix-term/src/handlers/collab.rs
@@ -7,7 +7,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 pub fn register_hooks(requests: UnboundedSender<p2p::Request>) {
     register_hook!(move |event: &mut DocumentDidChange<'_>| {
-        if event.ghost_transaction {
+        if event.ghost_transaction || event.remote_transaction {
             return Ok(());
         }
         let Some(crdt) = event.doc.crdt.as_mut() else {

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1671,7 +1671,6 @@ impl Document {
         }
         success
     }
-
     /// Apply a [`Transaction`] to the [`Document`] to change its text.
     pub fn apply(&mut self, transaction: &Transaction, view_id: ViewId) -> bool {
         self.apply_inner(transaction, view_id, true)

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -34,7 +34,7 @@ use std::sync::{Arc, Weak};
 use std::time::SystemTime;
 
 use helix_core::{
-    crdt::DocReplica,
+    crdt::Replica,
     editor_config::EditorConfig,
     encoding,
     history::{History, State, UndoKind},
@@ -193,7 +193,7 @@ pub struct Document {
     // be more troublesome.
     pub history: Cell<History>,
     /// Present only while the document is shared with a session.
-    pub crdt: Option<DocReplica>,
+    pub crdt: Option<Replica>,
     pub config: Arc<dyn DynAccess<Config>>,
 
     savepoints: Vec<Weak<SavePoint>>,
@@ -1678,7 +1678,7 @@ impl Document {
     /// the CRDT while still landing them in the rope.
     pub fn with_crdt_detached<T>(
         &mut self,
-        f: impl FnOnce(&mut Self, &mut DocReplica) -> T,
+        f: impl FnOnce(&mut Self, &mut Replica) -> T,
     ) -> Option<T> {
         let mut crdt = self.crdt.take()?;
         let out = f(self, &mut crdt);

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1672,20 +1672,6 @@ impl Document {
         success
     }
 
-    /// Detaches the replica for the body of `f`, so the change hook skips the
-    /// document and remote edits are not echoed back around the mesh.
-    /// `FnOnce` on purpose: an `.await` in there would drop keystrokes from
-    /// the CRDT while still landing them in the rope.
-    pub fn with_crdt_detached<T>(
-        &mut self,
-        f: impl FnOnce(&mut Self, &mut Replica) -> T,
-    ) -> Option<T> {
-        let mut crdt = self.crdt.take()?;
-        let out = f(self, &mut crdt);
-        self.crdt = Some(crdt);
-        Some(out)
-    }
-
     /// Apply a [`Transaction`] to the [`Document`] to change its text.
     pub fn apply(&mut self, transaction: &Transaction, view_id: ViewId) -> bool {
         self.apply_inner(transaction, view_id, true)

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -34,6 +34,7 @@ use std::sync::{Arc, Weak};
 use std::time::SystemTime;
 
 use helix_core::{
+    crdt::DocReplica,
     editor_config::EditorConfig,
     encoding,
     history::{History, State, UndoKind},
@@ -191,6 +192,8 @@ pub struct Document {
     // it back as it separated from the edits. We could split out the parts manually but that will
     // be more troublesome.
     pub history: Cell<History>,
+    /// Present only while the document is shared with a session.
+    pub crdt: Option<DocReplica>,
     pub config: Arc<dyn DynAccess<Config>>,
 
     savepoints: Vec<Weak<SavePoint>>,
@@ -754,6 +757,7 @@ impl Document {
             diagnostics: Vec::new(),
             version: 0,
             history: Cell::new(History::default()),
+            crdt: None,
             savepoints: Vec::new(),
             last_saved_time: SystemTime::now(),
             last_saved_revision: 0,
@@ -1667,6 +1671,21 @@ impl Document {
         }
         success
     }
+
+    /// Detaches the replica for the body of `f`, so the change hook skips the
+    /// document and remote edits are not echoed back around the mesh.
+    /// `FnOnce` on purpose: an `.await` in there would drop keystrokes from
+    /// the CRDT while still landing them in the rope.
+    pub fn with_crdt_detached<T>(
+        &mut self,
+        f: impl FnOnce(&mut Self, &mut DocReplica) -> T,
+    ) -> Option<T> {
+        let mut crdt = self.crdt.take()?;
+        let out = f(self, &mut crdt);
+        self.crdt = Some(crdt);
+        Some(out)
+    }
+
     /// Apply a [`Transaction`] to the [`Document`] to change its text.
     pub fn apply(&mut self, transaction: &Transaction, view_id: ViewId) -> bool {
         self.apply_inner(transaction, view_id, true)

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1629,6 +1629,7 @@ impl Document {
             old_text: &old_doc,
             changes,
             ghost_transaction: !emit_lsp_notification,
+            remote_transaction: transaction.is_remote(),
         });
 
         // if specified, the current selection should instead be replaced by transaction.selection

--- a/helix-view/src/events.rs
+++ b/helix-view/src/events.rs
@@ -14,7 +14,10 @@ events! {
         view: ViewId,
         old_text: &'a Rope,
         changes: &'a ChangeSet,
-        ghost_transaction: bool
+        ghost_transaction: bool,
+        // set when the transaction carried changes received from a remote peer,
+        // so the collaboration hook does not feed them back to the CRDT
+        remote_transaction: bool
     }
     DocumentDidClose<'a> {
         editor: &'a mut Editor,

--- a/helix-view/src/events.rs
+++ b/helix-view/src/events.rs
@@ -15,8 +15,6 @@ events! {
         old_text: &'a Rope,
         changes: &'a ChangeSet,
         ghost_transaction: bool,
-        // set when the transaction carried changes received from a remote peer,
-        // so the collaboration hook does not feed them back to the CRDT
         remote_transaction: bool
     }
     DocumentDidClose<'a> {

--- a/helix-view/src/p2p/mod.rs
+++ b/helix-view/src/p2p/mod.rs
@@ -1,10 +1,11 @@
-mod proto;
+pub mod proto;
 mod session;
 
 use iroh::{endpoint::presets, protocol::Router, Endpoint, EndpointId};
 use tokio::sync::mpsc::{unbounded_channel, Sender, UnboundedSender};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
+use proto::Message;
 use session::Session;
 
 pub const ALPN: &[u8] = b"helix/session/0";
@@ -13,7 +14,7 @@ pub const ALPN: &[u8] = b"helix/session/0";
 pub enum Event {
     Connected(EndpointId),
     Disconnected(EndpointId),
-    Message { from: EndpointId, data: Vec<u8> },
+    Message { from: EndpointId, message: Message },
     Error(String),
 }
 
@@ -23,7 +24,7 @@ pub enum Request {
     Join(String),
     Peers(Sender<Vec<EndpointId>>),
     Close,
-    Broadcast(Vec<u8>),
+    Broadcast(Message),
 }
 
 pub struct Service {
@@ -65,7 +66,7 @@ impl Service {
                         session.close();
                         continue;
                     }
-                    Request::Broadcast(data) => session.broadcast(data),
+                    Request::Broadcast(message) => session.broadcast(message),
                 };
 
                 if let Err(err) = result {

--- a/helix-view/src/p2p/proto.rs
+++ b/helix-view/src/p2p/proto.rs
@@ -10,18 +10,9 @@ const MAX_BODY_SIZE: usize = 16 * 1024 * 1024;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Message {
-    Hello {
-        addr: EndpointAddr,
-    },
-    Welcome {
-        peers: Vec<EndpointAddr>,
-    },
-    /// The initial handoff: the sharer's buffer, plus the encoded replica the
-    /// receiver forks its own from.
-    Share {
-        text: String,
-        replica: Vec<u8>,
-    },
+    Hello { addr: EndpointAddr },
+    Welcome { peers: Vec<EndpointAddr> },
+    Share { text: String, replica: Vec<u8> },
     Edit(RemoteOperation),
 }
 

--- a/helix-view/src/p2p/proto.rs
+++ b/helix-view/src/p2p/proto.rs
@@ -1,4 +1,5 @@
 use anyhow::{ensure, Result};
+use helix_core::crdt::Op;
 use iroh::{
     endpoint::{ReadExactError, RecvStream, SendStream},
     EndpointAddr,
@@ -9,9 +10,19 @@ const MAX_BODY_SIZE: usize = 16 * 1024 * 1024;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Message {
-    Hello { addr: EndpointAddr },
-    Welcome { peers: Vec<EndpointAddr> },
-    Data(Vec<u8>),
+    Hello {
+        addr: EndpointAddr,
+    },
+    Welcome {
+        peers: Vec<EndpointAddr>,
+    },
+    /// The initial handoff: the sharer's buffer, plus the encoded replica the
+    /// receiver forks its own from.
+    Share {
+        text: String,
+        replica: Vec<u8>,
+    },
+    Edit(Op),
 }
 
 pub fn encode(message: &Message) -> Result<Vec<u8>> {

--- a/helix-view/src/p2p/proto.rs
+++ b/helix-view/src/p2p/proto.rs
@@ -1,5 +1,5 @@
 use anyhow::{ensure, Result};
-use helix_core::crdt::Op;
+use helix_core::crdt::RemoteOperation;
 use iroh::{
     endpoint::{ReadExactError, RecvStream, SendStream},
     EndpointAddr,
@@ -22,7 +22,7 @@ pub enum Message {
         text: String,
         replica: Vec<u8>,
     },
-    Edit(Op),
+    Edit(RemoteOperation),
 }
 
 pub fn encode(message: &Message) -> Result<Vec<u8>> {

--- a/helix-view/src/p2p/session.rs
+++ b/helix-view/src/p2p/session.rs
@@ -78,12 +78,11 @@ impl Session {
         Ok(())
     }
 
-    pub fn broadcast(&self, data: Vec<u8>) -> Result<()> {
+    pub fn broadcast(&self, message: Message) -> Result<()> {
         let peers = self.peers.lock().unwrap();
-        ensure!(!peers.is_empty(), "not in a session");
 
         for peer in peers.values() {
-            let _ = peer.outbox.send(Message::Data(data.clone()));
+            let _ = peer.outbox.send(message.clone());
         }
         Ok(())
     }
@@ -240,7 +239,7 @@ impl Session {
 
     fn handle(&self, from: EndpointId, message: Message) {
         match message {
-            Message::Data(data) => self.emit(Event::Message { from, data }),
+            Message::Share { .. } | Message::Edit(_) => self.emit(Event::Message { from, message }),
             Message::Hello { .. } | Message::Welcome { .. } => self.report(format!(
                 "unexpected handshake message from {}",
                 from.fmt_short()


### PR DESCRIPTION
Two `hx` instances can now type into the same buffer. Peer B joins A's ticket, A runs `:session-share`, and from then on characters typed in either window appear in the other.

## Conversion layer

`helix-core/src/crdt.rs` translates between a `ChangeSet` and [cola](https://github.com/nomad/cola), a text CRDT. `from_local` turns a local change into the ops to send, `from_remote` turns a remote op into the `Transaction` to apply.

## Wire format

raw data is gone and the collaboration messages go straight into `proto::Message`:

## Sending and receiving

Sending is handled at `DocumentDidChange` hook. It is handed the `ChangeSet` directly, which is translated to remote operations. Remote operations are applied to the document.

## Commands

`:session-send` is removed, and `:session-share` is added, which creates the replica for the focused document and ships a snapshot to everyone connected.
